### PR TITLE
case insensitivity on lookup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elaine"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/recognize.rs
+++ b/src/recognize.rs
@@ -300,12 +300,12 @@ where
     }
 
     if let Some(complete) = stack.pop() {
-      builder.insert(complete)?;
+      builder = builder.insert(complete)?;
     }
   }
 
   if let Some(last) = stack.fin() {
-    builder.insert(last)?;
+    builder = builder.insert(last)?;
   }
 
   Ok(builder.collect::<Head>())


### PR DESCRIPTION
http headers [should be treated as case-insentive](https://tools.ietf.org/html/rfc2616#section-4.2); updating to lowercase during comparisons.